### PR TITLE
webpack.config.ts の型エラーを修正

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -4,7 +4,11 @@ import HtmlWebpackPlugin from "html-webpack-plugin"
 import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin"
 import { CleanWebpackPlugin } from "clean-webpack-plugin"
 import TerserWebpackPlugin from "terser-webpack-plugin"
-import { Configuration } from "webpack-dev-server"
+import { Configuration as WebpackDevServerConfigration } from "webpack-dev-server"
+
+interface Configuration extends webpack.Configuration {
+  devServer?: WebpackDevServerConfigration
+}
 
 const isProduction = process.env.NODE_ENV === "production"
 
@@ -19,7 +23,7 @@ const plugins: webpack.WebpackPluginInstance[] = isProduction
   ? [...commonPlugins, new CleanWebpackPlugin()]
   : [...commonPlugins]
 
-const devServer: Configuration = {
+const devServer: WebpackDevServerConfigration = {
   static: {
     directory: path.resolve(__dirname, "/dist"),
   },
@@ -32,7 +36,7 @@ const devServer: Configuration = {
   },
 }
 
-const config: webpack.Configuration = {
+const config: webpack.Configuration | Configuration = {
   mode: isProduction ? "production" : "development",
   entry: "./src/index.tsx",
   devtool: isProduction ? false : "inline-source-map",


### PR DESCRIPTION
# 概要

リモートからpullし、`yarn`を実行した上で`yarn run dev`から起動を試みたが、私の環境で以下のようなエラーが出たため修正した。

```
❯ yarn run dev
yarn run v1.22.11
$ cross-env TS_NODE_PROJECT='tsconfig.webpack.json' webpack serve
[webpack-cli] Failed to load '/home/caffeine/DevelopEnv/git_repos/club-portal-frontend/webpack.config.ts' config
[webpack-cli] webpack.config.ts:128:3 - error TS2322: Type '{ mode: "production" | "development"; entry: string; devtool: false | "inline-source-map"; output: { path: string; filename: string; assetModuleFilename: string; }; plugins: webpack.WebpackPluginInstance[]; ... 4 more ...; devServer: Configuration; }' is not assignable to type 'Configuration'.
  Object literal may only specify known properties, and 'devServer' does not exist in type 'Configuration'.

128   devServer: devServer,
      ~~~~~~~~~~~~~~~~~~~~

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

# 環境

Ubuntu 20.04
```
❯ yarn --version
1.22.11
```

# 修正箇所

### webpack.config.ts
`webpack.Configuration` を継承した型 `Configuration` を定義
メンバーとして `webpack-dev-server.Configuration` を追加