### PR TITLE
px指定をrem/em指定に変更

### DIFF
--- a/src/components/common/Button/MenuButton.tsx
+++ b/src/components/common/Button/MenuButton.tsx
@@ -9,10 +9,10 @@ export const MenuButton: React.VFC<
   React.PropsWithChildren<PortalButtonProps & mbprops>
 > = (props) => {
   const type = props.mbtype ?? "main"
-  const height = type === "main" ? "3.5em" : "2.5em"
+  const height = type === "main" ? "4.25rem" : "3rem"
 
   return (
-    <PortalButton width="340px" height={height} fontSize="1.25rem" {...props}>
+    <PortalButton width="20rem" height={height} fontSize="1.25rem" {...props}>
       {props.children}
     </PortalButton>
   )

--- a/src/components/common/Button/MenuButton.tsx
+++ b/src/components/common/Button/MenuButton.tsx
@@ -9,10 +9,10 @@ export const MenuButton: React.VFC<
   React.PropsWithChildren<PortalButtonProps & mbprops>
 > = (props) => {
   const type = props.mbtype ?? "main"
-  const height = type === "main" ? "67px" : "50px"
+  const height = type === "main" ? "3.5em" : "2.5em"
 
   return (
-    <PortalButton width="340px" height={height} fontSize="20px" {...props}>
+    <PortalButton width="340px" height={height} fontSize="1.25rem" {...props}>
       {props.children}
     </PortalButton>
   )

--- a/src/components/common/Button/PortalButton.tsx
+++ b/src/components/common/Button/PortalButton.tsx
@@ -34,7 +34,7 @@ export const PortalButton: React.VFC<
 
   // default height and width
   const width = props.width ?? sizeMap[size]
-  const height = props.height ?? "41px"
+  const height = props.height ?? "2.5rem"
 
   // default style prop
   const style = props.pbstyle ?? "fill"

--- a/src/components/common/Button/PortalButton.tsx
+++ b/src/components/common/Button/PortalButton.tsx
@@ -15,8 +15,8 @@ const isRound = (style: ButtonStyle): style is ButtonRoundStyle =>
   style === "round-fill" || style === "round-solid"
 
 const sizeMap: { [key in ButtonSize]: string } = {
-  normal: "157px",
-  large: "253px",
+  normal: "10rem",
+  large: "16rem",
   "100%": "100%",
 }
 

--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -1,1 +1,2 @@
 export { MenuButton } from "./MenuButton"
+export { PortalButton } from "./PortalButton"

--- a/src/components/global/Footer.tsx
+++ b/src/components/global/Footer.tsx
@@ -3,10 +3,8 @@ import { PortalLogo } from "../common/Logo"
 
 // TODO: サイトページの説明用のページ/コンポーネントを作成する
 export const Footer: React.VFC<{}> = () => {
-  const footerHeight = 198
-
   return (
-    <Center h={`${footerHeight}px`} backgroundColor="green.500">
+    <Center h="12rem" backgroundColor="green.500">
       <Flex direction="column">
         <Center>
           <PortalLogo boxSize="3em" mr="5" />

--- a/src/components/global/Header.tsx
+++ b/src/components/global/Header.tsx
@@ -3,15 +3,13 @@ import { Center, Flex, Spacer, Icon } from "@chakra-ui/react"
 import { DefaultUserIcon } from "../common/DefaultUserIcon"
 
 export const Header: React.VFC<{}> = () => {
-  const headerHeight = 52
-
   return (
-    <Flex px="15" h={`${headerHeight}px`} w="100%" backgroundColor="green.200">
+    <Flex px="1rem" h="3rem" w="100%" backgroundColor="green.200">
       <Center>
         <Icon as={BsList} boxSize="2em" color="text.title.main" />
       </Center>
       <Spacer />
-      <Center mr="15px">
+      <Center mr="1rem">
         <Icon as={BsBellFill} boxSize="2em" color="text.title.sub" />
       </Center>
       <Center>

--- a/src/pages/top.tsx
+++ b/src/pages/top.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   Center,
   Flex,
   Grid,
@@ -9,17 +10,17 @@ import {
 } from "@chakra-ui/react"
 import React from "react"
 import { PortalLogo } from "../components/common/Logo"
-import { MenuButton } from "../components/common/Button"
+import { MenuButton, PortalButton } from "../components/common/Button"
 import { BsSearch, BsMegaphone, BsClockHistory, BsStar } from "react-icons/bs"
 
 const AnimatedTop: React.VFC<{}> = () => {
   return (
     <Flex flex="1" bgGradient="radial(#ffffff, green.100)">
-      <VStack flex="1" spacing="66px">
+      <VStack flex="1" spacing="4rem">
         <Heading
-          pt="80px"
+          pt="5rem"
           fontFamily="futura-pt-bold"
-          fontSize="70px"
+          fontSize="4.5rem"
           color="green.900"
           textAlign="justify"
         >
@@ -29,7 +30,7 @@ const AnimatedTop: React.VFC<{}> = () => {
         <Grid
           templateRows="repeat(3, 1fr)"
           templateColumns="repeat(2, 1fr)"
-          columnGap="40px"
+          columnGap="2.5rem"
         >
           {/* ----- left content ----- */}
           <GridItem rowSpan={3}>
@@ -88,6 +89,10 @@ const AnimatedTop: React.VFC<{}> = () => {
             </Flex>
           </GridItem>
         </Grid>
+        <VStack>
+          <PortalButton> normal </PortalButton>
+          <PortalButton pbsize="large"> large </PortalButton>
+        </VStack>
       </VStack>
     </Flex>
   )

--- a/src/pages/top.tsx
+++ b/src/pages/top.tsx
@@ -1,12 +1,12 @@
 import {
-  Button,
-  Center,
+  Box,
   Flex,
   Grid,
   GridItem,
   Heading,
   Spacer,
   VStack,
+  Center
 } from "@chakra-ui/react"
 import React from "react"
 import { PortalLogo } from "../components/common/Logo"
@@ -31,29 +31,31 @@ const AnimatedTop: React.VFC<{}> = () => {
           templateRows="repeat(3, 1fr)"
           templateColumns="repeat(2, 1fr)"
           columnGap="2.5rem"
-        >
+          rowGap="1rem"
+      >
           {/* ----- left content ----- */}
           <GridItem rowSpan={3}>
             <Grid
               templateRows="repeat(3, 1fr)"
               templateColumns="repeat(1, 1fr)"
+              h="100%"
+              rowGap="1rem"
             >
               <GridItem rowSpan={2}>
-                <Center>
-                  <PortalLogo h="181px" w="auto" />
+                <Center h="100%">
+                  <PortalLogo minH="100%" w="auto" />
                 </Center>
               </GridItem>
               <GridItem rowSpan={1}>
                 <Flex
-                  w="360px"
+                  w="20rem"
                   p="0"
                   m="0"
-                  fontSize="16px/18"
+                  fontSize="1rem/18"
                   color="text.main"
                   textAlign="center"
                 >
-                  TUT Club
-                  Portalは東京工科大学のサークル情報を掲載する大学公認Webサイトです。
+                  TUT Club Portalは東京工科大学のサークル情報を掲載する大学公認Webサイトです。
                 </Flex>
               </GridItem>
             </Grid>
@@ -68,7 +70,7 @@ const AnimatedTop: React.VFC<{}> = () => {
             </MenuButton>
           </GridItem>
           <GridItem>
-            <Flex width="340px">
+            <Flex width="20rem">
               <MenuButton
                 flex="4"
                 mbtype="sub"
@@ -77,7 +79,7 @@ const AnimatedTop: React.VFC<{}> = () => {
               >
                 履歴
               </MenuButton>
-              <Spacer width="25px" />
+              <Spacer width="1.5rem" />
               <MenuButton
                 flex="6"
                 mbtype="sub"
@@ -89,10 +91,6 @@ const AnimatedTop: React.VFC<{}> = () => {
             </Flex>
           </GridItem>
         </Grid>
-        <VStack>
-          <PortalButton> normal </PortalButton>
-          <PortalButton pbsize="large"> large </PortalButton>
-        </VStack>
       </VStack>
     </Flex>
   )

--- a/src/pages/top.tsx
+++ b/src/pages/top.tsx
@@ -1,16 +1,15 @@
 import {
-  Box,
   Flex,
   Grid,
   GridItem,
   Heading,
   Spacer,
   VStack,
-  Center
+  Center,
 } from "@chakra-ui/react"
 import React from "react"
 import { PortalLogo } from "../components/common/Logo"
-import { MenuButton, PortalButton } from "../components/common/Button"
+import { MenuButton } from "../components/common/Button"
 import { BsSearch, BsMegaphone, BsClockHistory, BsStar } from "react-icons/bs"
 
 const AnimatedTop: React.VFC<{}> = () => {
@@ -32,7 +31,7 @@ const AnimatedTop: React.VFC<{}> = () => {
           templateColumns="repeat(2, 1fr)"
           columnGap="2.5rem"
           rowGap="1rem"
-      >
+        >
           {/* ----- left content ----- */}
           <GridItem rowSpan={3}>
             <Grid
@@ -55,7 +54,8 @@ const AnimatedTop: React.VFC<{}> = () => {
                   color="text.main"
                   textAlign="center"
                 >
-                  TUT Club Portalは東京工科大学のサークル情報を掲載する大学公認Webサイトです。
+                  TUT Club
+                  Portalは東京工科大学のサークル情報を掲載する大学公認Webサイトです。
                 </Flex>
               </GridItem>
             </Grid>


### PR DESCRIPTION
# 概要

`px` で指定していたものをなるべく `rem / em` にした。

# 詳細

要素の `width / height` や `margin / padding` 、フォントサイズなどが `px` 指定だったが、これを `rem / em` に直した。
理由は

- アクセシビリティを高めるため
- コードの見栄えを良くするため
- コードのメンテナンスをしやすくするため
- この段階なら大幅な変更を加えても大丈夫そうなため
    - 実際今回のリファクタリングにはそこまで時間が掛からなかった

である。
`border-width` など一部の属性は `px` 指定のままにしている。

# 今後のレイアウトについて

途中からの変更で申し訳ないけれど、大きさ指定の方針も

　「AdobeXDのデザイン案の `pt`数を `px`数として準拠させる」

から

　「AdobeXDのデザイン案から大きくズレない程度に `rem / em` に直す」

に路線変更できればなと思います。

理由は、「AdobeXDのデザインは飽くまで視覚的な基準であり、コードに落とし込む際に都合の良い単位に直せば良い」と考えたからです。