### PR TITLE
{...props} による全要素の展開を無くす

### DIFF
--- a/src/components/common/Button/MenuButton.stories.tsx
+++ b/src/components/common/Button/MenuButton.stories.tsx
@@ -27,6 +27,5 @@ export const Default = Template.bind({})
 
 Default.args = {
   mbtype: "main",
-  height: "4.25rem",
   children: "foo",
 }

--- a/src/components/common/Button/MenuButton.tsx
+++ b/src/components/common/Button/MenuButton.tsx
@@ -1,19 +1,24 @@
-import { PortalButtonProps } from "../../../types/button"
+import type { MenuButtonProps } from "../../../types/button"
 import { PortalButton } from "./PortalButton"
 
-type mbprops = {
-  mbtype?: "main" | "sub"
-}
-
-export const MenuButton: React.VFC<
-  React.PropsWithChildren<PortalButtonProps & mbprops>
-> = (props) => {
+export const MenuButton: React.VFC<React.PropsWithChildren<MenuButtonProps>> = (
+  props
+) => {
   const type = props.mbtype ?? "main"
   const height = type === "main" ? "4.25rem" : "3rem"
   const width = type === "main" ? "20rem" : "100%"
 
   return (
-    <PortalButton width={width} height={height} fontSize="1.25rem" {...props}>
+    <PortalButton
+      width={width}
+      height={height}
+      fontSize="1.25rem"
+      leftIcon={props.leftIcon}
+      flex={props.flex}
+      pbcolor={props.pbcolor}
+      pbsize={props.pbsize}
+      pbstyle={props.pbstyle}
+    >
       {props.children}
     </PortalButton>
   )

--- a/src/components/common/Button/PortalButton.tsx
+++ b/src/components/common/Button/PortalButton.tsx
@@ -71,6 +71,7 @@ export const PortalButton: React.VFC<
       backgroundColor={bgColor}
       _hover={hoverStyle}
       _focus={{}}
+      {...props}
     >
       {props.children}
     </Button>

--- a/src/components/common/Button/PortalButton.tsx
+++ b/src/components/common/Button/PortalButton.tsx
@@ -69,9 +69,11 @@ export const PortalButton: React.VFC<
       borderColor={borderColor}
       borderWidth="1px"
       backgroundColor={bgColor}
+      leftIcon={props.leftIcon}
+      flex={props.flex}
+      fontSize={props.fontSize}
       _hover={hoverStyle}
       _focus={{}}
-      {...props}
     >
       {props.children}
     </Button>

--- a/src/types/button.ts
+++ b/src/types/button.ts
@@ -4,11 +4,26 @@ export type ButtonSize = "normal" | "large" | "100%"
 export type ButtonStyle = "fill" | "solid" | "round-fill" | "round-solid"
 export type ButtonColor = "green" | "orange" | "yellow"
 
-export type PortalButtonProps = ButtonProps & {
+type CommonPickedProps = Pick<ButtonProps, "leftIcon" | "flex">
+
+type CommonProps = CommonPickedProps & {
   pbsize?: ButtonSize // specify template width of button (default is 'normal')
   pbstyle?: ButtonStyle // specify style like rounded or square, filled or solid (default is 'fill')
   pbcolor?: ButtonColor // specify color theme (default is 'green')
 }
+
+type MenuButtonInternalProps = {
+  mbtype?: "main" | "sub"
+}
+
+export type MenuButtonProps = CommonProps & MenuButtonInternalProps
+
+type PortalButtonInternalProps = Pick<
+  ButtonProps,
+  "width" | "height" | "fontSize"
+>
+
+export type PortalButtonProps = CommonProps & PortalButtonInternalProps
 
 export type ButtonSolidStyle = "solid" | "round-solid"
 export type ButtonRoundStyle = "round-fill" | "round-solid"


### PR DESCRIPTION
# 目的

現状では、`PortalButtonProps` がChakra UIの `ButtonProps` のPropertyを全部含んでおり、`PortalButton` が返却する `Button` コンポーネントに `{...props}` で全要素を渡している。
このブランチでは `ButtonProps` から必要な要素のみを抽出するようにし、コードの見通しを良くする。