### PR TITLE
サークル紹介ページのレイアウト修正

### DIFF
--- a/src/components/common/ClubDescription/CarouselGallery.tsx
+++ b/src/components/common/ClubDescription/CarouselGallery.tsx
@@ -1,4 +1,14 @@
-import { GridItem, Image, AspectRatio } from "@chakra-ui/react"
+import {
+  GridItem,
+  Image,
+  AspectRatio,
+  Text,
+  Flex,
+  Box,
+  Center,
+  HStack,
+  useMediaQuery,
+} from "@chakra-ui/react"
 import SwiperCore, { Navigation, Pagination } from "swiper"
 import { Swiper, SwiperSlide } from "swiper/react"
 import type { CarouselGalleryProps } from "../../../types/description"
@@ -7,10 +17,20 @@ import "swiper/css/bundle"
 SwiperCore.use([Pagination, Navigation])
 
 export const CarouselGallery: React.VFC<CarouselGalleryProps> = (props) => {
+  const numImages = props.imagePaths.length
+
+  const [is1slides, is2slides] = useMediaQuery([
+    "(min-width: 30em)",
+    "(min-width: 48em)",
+  ])
+  let slidesPerView = 0
+  if (is1slides) slidesPerView = 1
+  if (is2slides && numImages >= 2) slidesPerView = 2
+
   return (
     <GridItem colSpan={12}>
       <Swiper
-        slidesPerView={3}
+        slidesPerView={slidesPerView}
         spaceBetween={32}
         pagination={{
           clickable: true,
@@ -20,12 +40,14 @@ export const CarouselGallery: React.VFC<CarouselGalleryProps> = (props) => {
       >
         {props.imagePaths.map((path, i) => (
           <SwiperSlide key={i}>
-            <AspectRatio ratio={16 / 9}>
-              <Image
-                src={`${location.protocol}//${location.host}/${path}`}
-                maxHeight="15rem"
-              />
-            </AspectRatio>
+            <Center>
+              <AspectRatio
+                ratio={16 / 9}
+                w={{ sm: "90%", md: "70%", lg: "60%" }}
+              >
+                <Image src={`${location.protocol}//${location.host}/${path}`} />
+              </AspectRatio>
+            </Center>
           </SwiperSlide>
         ))}
       </Swiper>

--- a/src/components/common/ClubDescription/IntroductionVideo.tsx
+++ b/src/components/common/ClubDescription/IntroductionVideo.tsx
@@ -3,12 +3,12 @@ import type { IntroductionVideoProps } from "../../../types/description"
 
 export const IntroductionVideo: React.VFC<IntroductionVideoProps> = (props) => {
   return props.videoPath ? (
-    <GridItem colSpan={12} width="50%" justifySelf="center">
-      <VStack spacing="1rem">
+    <GridItem colSpan={12} justifySelf="center">
+      <VStack spacing="1rem" w="100%">
         <Text fontSize="1.5rem" color="text.main">
           紹介動画
         </Text>
-        <AspectRatio ratio={16 / 9} width="100%">
+        <AspectRatio ratio={16 / 9} width={{ sm: "60vw", lg: "40vw" }}>
           <iframe
             width="100%"
             height="100%"


### PR DESCRIPTION
# 修正箇所

- 紹介動画
- カルーセルギャラリー

## 紹介動画

ViwePort幅に応じて幅を変更するようにした

![Peek 2022-03-16 18-16](https://user-images.githubusercontent.com/48763656/158556905-6d6d3a78-d12f-40db-9a34-71a7958e6469.gif)

## カルーセルギャラリー

ViewPort幅と画像の枚数に応じて

- スライド1枚の幅
- 表示するスライドの数

を変更するようにした

### 写真が1枚の場合
- ViewPort幅に関わらずスライド表示数は1枚
- スライド1枚の幅は可変

![Peek 2022-03-16 18-19](https://user-images.githubusercontent.com/48763656/158557446-49d0b7ee-0f44-4e2f-8af9-5f1e467ebc27.gif)

### 写真が2枚以上の場合
- 表示スライド2枚、ViewPortt幅が小さい場合は表示スライド1枚
- スライド1枚の幅は可変

![Peek 2022-03-16 18-21](https://user-images.githubusercontent.com/48763656/158557804-66637415-b2bd-450c-acd4-7154018c2202.gif)

