### PR TITLE
外部リンクエディターに「その他」の入力を追加

### DIFF
--- a/src/pages/editor/description.tsx
+++ b/src/pages/editor/description.tsx
@@ -49,7 +49,7 @@ export const DescriptionEditor: React.VFC<{}> = () => {
 
   const onSubmit = handleSubmit(async (data) => {
     const requestConfig: AxiosRequestConfig<Description> = {
-      url: `/api/v1/uuid/${clubUuid!}/description`,
+      url: `/api/v1/clubs/uuid/${clubUuid!}/description`,
       method: "put",
       data: data,
     }

--- a/src/pages/editor/link.tsx
+++ b/src/pages/editor/link.tsx
@@ -9,7 +9,7 @@ import {
   VStack,
   Wrap,
 } from "@chakra-ui/react"
-import { useEffect, useState } from "react"
+import { ChangeEvent, useEffect, useState } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { EditorBase } from "../../components/common/Editor/EditorBase"
@@ -63,8 +63,6 @@ export const LinkEditor: React.VFC<{}> = () => {
   const values = watch()
 
   const onAdd = () => {
-    console.log(values)
-
     let err = false
     if (values.label === "" && !isOther) {
       err = true
@@ -99,7 +97,7 @@ export const LinkEditor: React.VFC<{}> = () => {
       }
 
       if (!err) {
-        values.label = "Sonota"
+        values.label = values.otherLabel
       }
     }
 
@@ -111,6 +109,21 @@ export const LinkEditor: React.VFC<{}> = () => {
       })
     } else {
       clearErrors("url")
+    }
+
+    let isExist = false
+    for (const item of items) {
+      if (values.label === item.label && values.url === item.url) {
+        console.log(values.label, values.url)
+        isExist = true
+      }
+    }
+    if (isExist) {
+      err = true
+      setError("url", {
+        type: "validate",
+        message: "既に登録済みです"
+      })
     }
 
     if (!err) {
@@ -158,11 +171,12 @@ export const LinkEditor: React.VFC<{}> = () => {
                     <Select
                       backgroundColor="#fff"
                       w="12rem"
-                      {...register("label")}
+                      {...register("label", {
+                        onChange: (e: ChangeEvent<HTMLSelectElement>) => {
+                          setIsOther(e.target.value === "other")
+                        },
+                      })}
                       defaultValue=""
-                      onChange={(e) => {
-                        setIsOther(e.target.value === "other")
-                      }}
                     >
                       <option value="" hidden>
                         -
@@ -225,7 +239,7 @@ export const LinkEditor: React.VFC<{}> = () => {
             <Stack w="100%">
               {items.map((item) => {
                 return (
-                  <HStack key={item.label} textColor="text.main">
+                  <HStack key={item.label + item.url} textColor="text.main">
                     <EditorButton
                       icon="remove"
                       onClick={() => onRemove(item)}

--- a/src/pages/editor/link.tsx
+++ b/src/pages/editor/link.tsx
@@ -32,7 +32,7 @@ import { EditorLabel } from "../../components/common/Editor/EditorInput"
 const schema = z.object({
   label: z.string(),
   url: z.string().url(),
-  otherLabel: z.string().optional()
+  otherLabel: z.string().optional(),
 })
 
 export const LinkEditor: React.VFC<{}> = () => {
@@ -112,7 +112,7 @@ export const LinkEditor: React.VFC<{}> = () => {
 
     let isExist = false
     for (const item of items) {
-      const label =  isOther ? values.otherLabel!.trim() : values.label.trim()
+      const label = isOther ? values.otherLabel!.trim() : values.label.trim()
       if (label === item.label && values.url.trim() === item.url) {
         isExist = true
       }
@@ -126,7 +126,10 @@ export const LinkEditor: React.VFC<{}> = () => {
     }
 
     if (!err) {
-      const v: Link = { label: isOther ? values.otherLabel!.trim() : values.label.trim(), url: values.url }
+      const v: Link = {
+        label: isOther ? values.otherLabel!.trim() : values.label.trim(),
+        url: values.url,
+      }
       setItems([v, ...items])
     }
   }
@@ -204,7 +207,7 @@ export const LinkEditor: React.VFC<{}> = () => {
                       textColor="text.main"
                       placeholder="その他のSNSを入力"
                       {...register("otherLabel", {
-                        disabled: !isOther
+                        disabled: !isOther,
                       })}
                     />
                     <Wrap h="1.2rem">

--- a/src/pages/editor/link.tsx
+++ b/src/pages/editor/link.tsx
@@ -63,6 +63,8 @@ export const LinkEditor: React.VFC<{}> = () => {
   const values = watch()
 
   const onAdd = () => {
+    console.log(values)
+
     let err = false
     if (values.label === "" && !isOther) {
       err = true
@@ -75,7 +77,7 @@ export const LinkEditor: React.VFC<{}> = () => {
     }
 
     if (isOther) {
-      if (values.otherLabel === "") {
+      if (values.otherLabel === "" || values.otherLabel === undefined) {
         err = true
         setError("otherLabel", {
           type: "required",
@@ -204,10 +206,12 @@ export const LinkEditor: React.VFC<{}> = () => {
                       backgroundColor="#fff"
                       textColor="text.main"
                       placeholder="その他のSNSを入力"
+                      defaultValue=""
                       {...register("otherLabel", {
                         required: isOther,
-                        disabled: !isOther,
                       })}
+                      // ↓registerに含めると不具合発生
+                      disabled={!isOther}
                     />
                     <Wrap h="1.2rem">
                       <FormErrorMessage w="12rem">

--- a/src/pages/editor/link.tsx
+++ b/src/pages/editor/link.tsx
@@ -138,6 +138,7 @@ export const LinkEditor: React.VFC<{}> = () => {
                         </option>
                       )
                     })}
+                    <option>その他</option>
                   </Select>
                   <Wrap h="1.2rem">
                     <FormErrorMessage>

--- a/src/pages/editor/link.tsx
+++ b/src/pages/editor/link.tsx
@@ -122,7 +122,7 @@ export const LinkEditor: React.VFC<{}> = () => {
       err = true
       setError("url", {
         type: "validate",
-        message: "既に登録済みです"
+        message: "既に登録済みです",
       })
     }
 

--- a/src/pages/editor/video.tsx
+++ b/src/pages/editor/video.tsx
@@ -148,7 +148,7 @@ export const VideoEditor: React.VFC<{}> = () => {
 
   const onSubmit = handleSubmit(async (data) => {
     const requestConfig: AxiosRequestConfig<Array<Video>> = {
-      url: `/api/v1/uuid/${clubUuid!}/video`,
+      url: `/api/v1/clubs/uuid/${clubUuid!}/video`,
       method: "put",
       data: [data],
     }


### PR DESCRIPTION
# 変更箇所

- `Select` の `option` に「その他」を追加し、「その他」が選択された場合に `Input` を有効化させた
- 既に登録されたリンクを登録しようとした場合にエラーを出すようにした
  - `label` と `url` の両方が既存の場合に判定する → 異なる `label` で同じ `url` は登録可能（用途は不明だが...）

- `items` を列挙する要素のkey属性を `label` から `label + url` に変更した
  - 該当コード↓

https://github.com/lc-tut/club-portal-frontend/blob/c267dc8b4f29c8737e93555bbf882cc07ddf4fb8/src/pages/editor/link.tsx#L239-L253

- 「その他」に入力されたラベル名を扱う為、`useForm` のジェネリクス引数には `Link` と `{otherLabel: string}` の複合型を渡した
  - 該当コード↓

https://github.com/lc-tut/club-portal-frontend/blob/c267dc8b4f29c8737e93555bbf882cc07ddf4fb8/src/pages/editor/link.tsx#L42-L51

- 「その他」のラベル名は「先頭大文字の半角英数字」しか受け付けないようにした
  - NG: `test`
  - NG: `テスト`
  - OK: `Test`
  - OK: `Test123`
  - 該当コード↓

https://github.com/lc-tut/club-portal-frontend/blob/c267dc8b4f29c8737e93555bbf882cc07ddf4fb8/src/pages/editor/link.tsx#L84-L94

デモ（録画ソフトの不具合でサブリミナル的にでじこが来ます）
![link](https://user-images.githubusercontent.com/48763656/158663623-849ec80a-37ca-4a82-967c-b8784c125aeb.gif)
 
# 補足

`onSubmit()` には変更を加えていません。「その他」のラベルを入力した場合そのラベル名で `items` に登録されます。
ただ、こちらの環境では保存ボタンを押した後にエラーが出てしまうので、検証はできていません。

![image](https://user-images.githubusercontent.com/48763656/158666876-49d50950-338c-4398-a928-fe9f1b29295d.png)
![image](https://user-images.githubusercontent.com/48763656/158666953-ac33b42d-14d0-46aa-ae1c-041a53ae645d.png)

club-portal の pull はしてみました。
```
ebe9208 (HEAD -> dev, origin/dev, origin/HEAD) Merge pull request #46 from lc-tut/improve-favs
```