### PR TITLE
ユーザーの閲覧制限を追加

### DIFF
--- a/src/components/common/Button/FavoriteButton.tsx
+++ b/src/components/common/Button/FavoriteButton.tsx
@@ -18,6 +18,9 @@ export const FavoriteButton: React.VFC<FavoriteButtonProps> = (props) => {
       isDisabled={props.isDisabled}
       onClick={props.onClick}
       isLoading={isLoading}
+      _hover={{
+        opacity: 0.6,
+      }}
     >
       {text}
     </Button>

--- a/src/components/common/ClubDescription/DescriptionText.tsx
+++ b/src/components/common/ClubDescription/DescriptionText.tsx
@@ -1,4 +1,12 @@
-import { GridItem, VStack, Text, HStack, Link, Button } from "@chakra-ui/react"
+import {
+  GridItem,
+  VStack,
+  Text,
+  HStack,
+  Link,
+  Button,
+  Center,
+} from "@chakra-ui/react"
 import {
   BsDiscord,
   BsInstagram,
@@ -35,44 +43,52 @@ const iconMap: { [key in SNSType]?: JSX.Element } = {
 }
 
 export const DescriptionText: React.VFC<DescriptionProps> = (props) => {
+  const colSpan = props.fullWidth ? 12 : { base: 12, md: 6 }
+  const width = props.fullWidth ? "50%" : "100%"
+  console.log(props.fullWidth, colSpan, width)
+
   return (
-    <GridItem colSpan={{ base: 12, md: 6 }}>
-      <VStack spacing="1rem">
-        <Text fontSize="1.5rem" color="text.main">
-          このサークルについて
-        </Text>
-        <Text color="text.main" px="1rem">
-          {props.content}
-        </Text>
-        <HStack alignSelf="start" px="1rem">
-          {props.links?.map((link) => {
-            const label = link.label
-            const registerdSNS = isRegisteredSNS(label)
-            return (
-              <Link href={link.path} key={link.path} isExternal _hover={{}}>
-                <Button
-                  color={registerdSNS ? fgColorMap[label] : "button.text.gray"}
-                  backgroundColor={
-                    registerdSNS ? bgColorMap[label] : "button.gray"
-                  }
-                  leftIcon={registerdSNS ? iconMap[label] : <BsLink />}
-                  fontSize="0.75rem"
-                  borderRadius="2px"
-                  height="2rem"
-                  minWidth="6rem"
-                  _hover={{
-                    opacity: 0.6,
-                  }}
-                  _focus={{}}
-                  _active={{}}
-                >
-                  {link.label}
-                </Button>
-              </Link>
-            )
-          })}
-        </HStack>
-      </VStack>
+    <GridItem colSpan={colSpan}>
+      <Center>
+        <VStack spacing="1rem" w={width}>
+          <Text fontSize="1.5rem" color="text.main">
+            このサークルについて
+          </Text>
+          <Text color="text.main" px="1rem">
+            {props.content}
+          </Text>
+          <HStack alignSelf="start" px="1rem">
+            {props.links?.map((link) => {
+              const label = link.label
+              const registerdSNS = isRegisteredSNS(label)
+              return (
+                <Link href={link.path} key={link.path} isExternal _hover={{}}>
+                  <Button
+                    color={
+                      registerdSNS ? fgColorMap[label] : "button.text.gray"
+                    }
+                    backgroundColor={
+                      registerdSNS ? bgColorMap[label] : "button.gray"
+                    }
+                    leftIcon={registerdSNS ? iconMap[label] : <BsLink />}
+                    fontSize="0.75rem"
+                    borderRadius="2px"
+                    height="2rem"
+                    minWidth="6rem"
+                    _hover={{
+                      opacity: 0.6,
+                    }}
+                    _focus={{}}
+                    _active={{}}
+                  >
+                    {link.label}
+                  </Button>
+                </Link>
+              )
+            })}
+          </HStack>
+        </VStack>
+      </Center>
     </GridItem>
   )
 }

--- a/src/pages/clubpage.tsx
+++ b/src/pages/clubpage.tsx
@@ -25,7 +25,6 @@ import { TitleArea } from "../components/global/Header/TitleArea"
 import { Loading } from "../components/global/LoadingPage"
 import { useAPI } from "../hooks/useAPI"
 import { useErrorToast } from "../hooks/useErrorToast"
-import { useSession } from "../hooks/useSession"
 import type {
   ClubPageInternal,
   FavoriteClubStatus,
@@ -42,8 +41,6 @@ type ClubPageProps = {
 // TODO: アニメーションをつける
 export const ClubPage: React.VFC<ClubPageProps> = (props) => {
   const clubSlug = useLocation()
-  const session = useSession()
-  const loc = useLocation()
   const { data, isLoading, isError } = useAPI<ClubPageInternal | null>(
     !clubSlug.pathname.startsWith("/clubs/")
       ? null
@@ -92,10 +89,8 @@ export const ClubPage: React.VFC<ClubPageProps> = (props) => {
   }
 
   const onLogin = () => {
-    window.location.href = `/api/auth/signin?redirect_url=${loc.pathname}`
+    window.location.href = `/api/auth/signin?redirect_url=${clubSlug.pathname}`
   }
-
-  console.log(session.session)
 
   return (
     <VStack flex="1">
@@ -114,7 +109,7 @@ export const ClubPage: React.VFC<ClubPageProps> = (props) => {
         </Flex>
         <Tooltip
           label="利用するには学生用Gmailアカウントでログインして下さい"
-          isDisabled={session.session?.role === "domain"}
+          isDisabled={props.userUUID === undefined}
         >
           <Wrap>
             <FavoriteButton
@@ -141,9 +136,9 @@ export const ClubPage: React.VFC<ClubPageProps> = (props) => {
             .filter((link) => link.label !== "HP" && link.label !== "Email")
             .map((link) => ({ label: link.label, path: link.url }))}
           content={data?.description ?? ""}
-          fullWidth={session.session === null}
+          fullWidth={props.userUUID === undefined}
         />
-        {session.session !== null ? (
+        {props.userUUID !== null ? (
           <>
             <DetailInformation
               activity={data?.contents.map((cont) => cont.content) ?? []}

--- a/src/pages/clubpage.tsx
+++ b/src/pages/clubpage.tsx
@@ -109,7 +109,7 @@ export const ClubPage: React.VFC<ClubPageProps> = (props) => {
         </Flex>
         <Tooltip
           label="利用するには学生用Gmailアカウントでログインして下さい"
-          isDisabled={props.userUUID === undefined}
+          isDisabled={props.userUUID !== undefined}
         >
           <Wrap>
             <FavoriteButton
@@ -138,7 +138,7 @@ export const ClubPage: React.VFC<ClubPageProps> = (props) => {
           content={data?.description ?? ""}
           fullWidth={props.userUUID === undefined}
         />
-        {props.userUUID !== null ? (
+        {props.userUUID !== undefined ? (
           <>
             <DetailInformation
               activity={data?.contents.map((cont) => cont.content) ?? []}

--- a/src/pages/clubpage.tsx
+++ b/src/pages/clubpage.tsx
@@ -114,7 +114,7 @@ export const ClubPage: React.VFC<ClubPageProps> = (props) => {
         </Flex>
         <Tooltip
           label="利用するには学生用Gmailアカウントでログインして下さい"
-          isDisabled={session.session?.role !== "domain"}
+          isDisabled={session.session?.role === "domain"}
         >
           <Wrap>
             <FavoriteButton

--- a/src/pages/clubpage.tsx
+++ b/src/pages/clubpage.tsx
@@ -1,14 +1,22 @@
-import { Flex, Grid, HStack, Icon, VStack } from "@chakra-ui/react"
+import {
+  Flex,
+  Grid,
+  GridItem,
+  HStack,
+  Icon,
+  Text,
+  VStack,
+} from "@chakra-ui/react"
 import { AxiosRequestConfig } from "axios"
 import { BsClock } from "react-icons/bs"
 import { useLocation } from "react-router-dom"
-import { FavoriteButton } from "../components/common/Button"
+import { FavoriteButton, PortalButton } from "../components/common/Button"
 import {
-  IntroductionVideo,
+  AnnualPlan,
   CarouselGallery,
   DescriptionText,
   DetailInformation,
-  AnnualPlan,
+  IntroductionVideo,
 } from "../components/common/ClubDescription"
 import { ClubTypeBadge } from "../components/common/Clubs/ClubTypeBadge"
 import { TitleArea } from "../components/global/Header/TitleArea"
@@ -31,6 +39,7 @@ type ClubPageProps = {
 // TODO: アニメーションをつける
 export const ClubPage: React.VFC<ClubPageProps> = (props) => {
   const clubSlug = useLocation()
+  const loc = useLocation()
   const { data, isLoading, isError } = useAPI<ClubPageInternal | null>(
     !clubSlug.pathname.startsWith("/clubs/")
       ? null
@@ -78,6 +87,10 @@ export const ClubPage: React.VFC<ClubPageProps> = (props) => {
     }
   }
 
+  const onLogin = () => {
+    window.location.href = `/api/auth/signin?redirect_url=${loc.pathname}`
+  }
+
   return (
     <VStack flex="1">
       <TitleArea subtitle={data?.shortDescription}>{data?.name}</TitleArea>
@@ -115,30 +128,44 @@ export const ClubPage: React.VFC<ClubPageProps> = (props) => {
             .filter((link) => link.label !== "HP" && link.label !== "Email")
             .map((link) => ({ label: link.label, path: link.url }))}
           content={data?.description ?? ""}
+          fullWidth={props.userUUID === undefined}
         />
-        <DetailInformation
-          activity={data?.contents.map((cont) => cont.content) ?? []}
-          activityDetail={
-            data?.activityDetails.map((tp) => ({
-              timeId: tp.timeId,
-              date: tp.date,
-              time: tp.time,
-              timeRemark: tp.timeRemark,
-              placeId: tp.placeId,
-              place: tp.place,
-              placeRemark: tp.placeRemark,
-            })) ?? []
-          }
-          achievements={data?.achievements.map((ach) => ach.achievement)}
-          mail={data?.links
-            .filter((link) => link.label === "Email")
-            .map((link) => link.url)}
-          website={data?.links
-            .filter((link) => link.label === "HP")
-            .map((link) => link.url)}
-          remark={data?.clubRemark}
-        />
-        <AnnualPlan schedules={schedule} remark={data?.scheduleRemark} />
+        {props.userUUID !== undefined ? (
+          <>
+            <DetailInformation
+              activity={data?.contents.map((cont) => cont.content) ?? []}
+              activityDetail={
+                data?.activityDetails.map((tp) => ({
+                  timeId: tp.timeId,
+                  date: tp.date,
+                  time: tp.time,
+                  timeRemark: tp.timeRemark,
+                  placeId: tp.placeId,
+                  place: tp.place,
+                  placeRemark: tp.placeRemark,
+                })) ?? []
+              }
+              achievements={data?.achievements.map((ach) => ach.achievement)}
+              mail={data?.links
+                .filter((link) => link.label === "Email")
+                .map((link) => link.url)}
+              website={data?.links
+                .filter((link) => link.label === "HP")
+                .map((link) => link.url)}
+              remark={data?.clubRemark}
+            />
+            <AnnualPlan schedules={schedule} remark={data?.scheduleRemark} />
+          </>
+        ) : (
+          <GridItem colSpan={12}>
+            <VStack>
+              <Text textColor="text.main">
+                大学Gmailアカウントでログインすると、全ての情報を閲覧することができます。
+              </Text>
+              <PortalButton onClick={onLogin}>ログイン</PortalButton>
+            </VStack>
+          </GridItem>
+        )}
       </Grid>
     </VStack>
   )

--- a/src/pages/clubpage.tsx
+++ b/src/pages/clubpage.tsx
@@ -25,6 +25,7 @@ import { TitleArea } from "../components/global/Header/TitleArea"
 import { Loading } from "../components/global/LoadingPage"
 import { useAPI } from "../hooks/useAPI"
 import { useErrorToast } from "../hooks/useErrorToast"
+import { useSession } from "../hooks/useSession"
 import type {
   ClubPageInternal,
   FavoriteClubStatus,
@@ -41,6 +42,7 @@ type ClubPageProps = {
 // TODO: アニメーションをつける
 export const ClubPage: React.VFC<ClubPageProps> = (props) => {
   const clubSlug = useLocation()
+  const session = useSession()
   const loc = useLocation()
   const { data, isLoading, isError } = useAPI<ClubPageInternal | null>(
     !clubSlug.pathname.startsWith("/clubs/")
@@ -93,6 +95,8 @@ export const ClubPage: React.VFC<ClubPageProps> = (props) => {
     window.location.href = `/api/auth/signin?redirect_url=${loc.pathname}`
   }
 
+  console.log(session.session)
+
   return (
     <VStack flex="1">
       <TitleArea subtitle={data?.shortDescription}>{data?.name}</TitleArea>
@@ -110,7 +114,7 @@ export const ClubPage: React.VFC<ClubPageProps> = (props) => {
         </Flex>
         <Tooltip
           label="利用するには学生用Gmailアカウントでログインして下さい"
-          isDisabled={props.userUUID !== undefined && !favs.isError}
+          isDisabled={session.session?.role !== "domain"}
         >
           <Wrap>
             <FavoriteButton
@@ -137,9 +141,9 @@ export const ClubPage: React.VFC<ClubPageProps> = (props) => {
             .filter((link) => link.label !== "HP" && link.label !== "Email")
             .map((link) => ({ label: link.label, path: link.url }))}
           content={data?.description ?? ""}
-          fullWidth={props.userUUID === undefined}
+          fullWidth={session.session === null}
         />
-        {props.userUUID !== undefined ? (
+        {session.session !== null ? (
           <>
             <DetailInformation
               activity={data?.contents.map((cont) => cont.content) ?? []}

--- a/src/pages/clubpage.tsx
+++ b/src/pages/clubpage.tsx
@@ -5,7 +5,9 @@ import {
   HStack,
   Icon,
   Text,
+  Tooltip,
   VStack,
+  Wrap,
 } from "@chakra-ui/react"
 import { AxiosRequestConfig } from "axios"
 import { BsClock } from "react-icons/bs"
@@ -106,12 +108,19 @@ export const ClubPage: React.VFC<ClubPageProps> = (props) => {
           <Icon as={BsClock} mr="5px" />
           最終更新: {data?.updatedAt}
         </Flex>
-        <FavoriteButton
-          isDisabled={props.userUUID === undefined || favs.isError}
-          isRegistered={favs.data?.status}
-          isLoading={props.userUUID ? favs.isLoading : false}
-          onClick={onClick}
-        />
+        <Tooltip
+          label="利用するには学生用Gmailアカウントでログインして下さい"
+          isDisabled={props.userUUID !== undefined && !favs.isError}
+        >
+          <Wrap>
+            <FavoriteButton
+              isDisabled={props.userUUID === undefined || favs.isError}
+              isRegistered={favs.data?.status}
+              isLoading={props.userUUID ? favs.isLoading : false}
+              onClick={onClick}
+            />
+          </Wrap>
+        </Tooltip>
       </HStack>
       <Grid
         templateColumns="repeat(12, 1fr)"

--- a/src/types/description.ts
+++ b/src/types/description.ts
@@ -12,6 +12,7 @@ export type IntroductionVideoProps = {
 export type DescriptionProps = {
   content: string
   links?: Array<{ label: string; path: string }>
+  fullWidth: boolean
 }
 
 export type DetailInformationProps = {


### PR DESCRIPTION
# サークル紹介ページの閲覧制限とログイン案内
詳細情報と年間スケジュールはログインしないと見れない仕様にした。
`session` の有無で判定している為、Domain, General, Admin全てのユーザーで閲覧可能。

ログイン時
![image](https://user-images.githubusercontent.com/48763656/158685012-8febecaf-e29a-481f-888a-5918e2011aaa.png)

未ログイン時
![image](https://user-images.githubusercontent.com/48763656/158682896-b4376f6a-2707-4fca-9d6a-90220e478fd6.png)

# お気に入りボタンの改善

General もしくは Admin でログインしている場合にお気に入りボタンが使えない仕様が少々分かりにくいと感じた。
そこで、Domainユーザーでログインしている時以外はToolTipを表示するようにした。

![image](https://user-images.githubusercontent.com/48763656/158686415-26297f58-f8d9-46b2-b7ad-ea6a76975c45.png)

`FavoriteButton` のホバー時のスタイルにも変更を加えた。

変更前
![image](https://user-images.githubusercontent.com/48763656/158687315-bd83831c-82bb-4f72-aa16-382818e0faf0.png)

# 補足

ちなみにお気に入りの動作確認できました。
ちゃんと動いててすげー