### PR TITLE
ローディング関連の問題の修正

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2,6 +2,7 @@ import { ChakraProvider } from "@chakra-ui/react"
 import { useState } from "react"
 import { SWRConfig } from "swr"
 
+import { LoadingOverlay } from "./components/global/LoadingPage"
 import { PortalTheme } from "./components/global/Theme"
 import { LoadingStateContext, SetLoadingStateContext } from "./contexts/loading"
 import { PortalRouter } from "./router"
@@ -9,7 +10,8 @@ import type { ErrorType } from "./types/utils"
 import { axiosFetcher } from "./utils/axios"
 
 const App: React.FC<{}> = () => {
-  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [isLoadingOuter, setIsLoadingOuter] = useState<boolean>(false)
+  const [isLoadingInner, setIsLoadingInner] = useState<boolean>(false)
   const [error, setError] = useState<ErrorType>(undefined)
 
   return (
@@ -17,22 +19,33 @@ const App: React.FC<{}> = () => {
       value={{
         fetcher: axiosFetcher,
         onSuccess: () => {
-          setIsLoading(false)
+          setIsLoadingOuter(false)
+          setIsLoadingInner(false)
         },
         onError: (err: ErrorType) => {
           setError(err)
-          setIsLoading(false)
+          setIsLoadingOuter(false)
+          setIsLoadingInner(false)
         },
       }}
     >
       <ChakraProvider theme={PortalTheme}>
         <SetLoadingStateContext.Provider
-          value={{ setIsLoading: setIsLoading, setError: setError }}
+          value={{
+            setIsLoadingOuter: setIsLoadingOuter,
+            setIsLoadingInner: setIsLoadingInner,
+            setError: setError,
+          }}
         >
           <LoadingStateContext.Provider
-            value={{ isLoading: isLoading, error: error }}
+            value={{
+              isLoadingOuter: isLoadingOuter,
+              isLoadingInner: isLoadingInner,
+              error: error,
+            }}
           >
             <PortalRouter />
+            <LoadingOverlay />
           </LoadingStateContext.Provider>
         </SetLoadingStateContext.Provider>
       </ChakraProvider>

--- a/src/components/common/Clubs/ClubFilter.tsx
+++ b/src/components/common/Clubs/ClubFilter.tsx
@@ -41,6 +41,7 @@ type FilterSwitchProps = {
 }
 
 type FilterAreaProps = FilterSwitchProps & {
+  keyword: string
   setKeyword: StateDispatch<string>
   isMobileLayout: boolean
 }
@@ -117,7 +118,7 @@ const FilterSwitch: React.FC<FilterSwitchProps> = (props) => {
 
 export const ClubFilter: React.FC<FilterAreaProps> = (props) => {
   const { isOpen, onOpen, onClose } = useDisclosure()
-  const { register, handleSubmit } = useForm<KeywordFormType>()
+  const { register, handleSubmit, setValue } = useForm<KeywordFormType>()
 
   const onSubmit = handleSubmit((data) => {
     props.setKeyword(data.keyword)
@@ -155,7 +156,10 @@ export const ClubFilter: React.FC<FilterAreaProps> = (props) => {
                 pbstyle="solid"
                 width="7rem"
                 onClick={() =>
-                  props.dispatchFilterValues({ type: RESET_FILTER })
+                  {props.dispatchFilterValues({ type: RESET_FILTER })
+                  props.setKeyword("")
+                  setValue("keyword", "")
+                }
                 }
               >
                 リセット
@@ -249,8 +253,9 @@ export const ClubFilter: React.FC<FilterAreaProps> = (props) => {
                       <PortalButton
                         pbstyle="solid"
                         width="7rem"
-                        onClick={() =>
+                        onClick={() => {
                           props.dispatchFilterValues({ type: RESET_FILTER })
+                        }
                         }
                       >
                         リセット

--- a/src/components/common/Clubs/ClubFilter.tsx
+++ b/src/components/common/Clubs/ClubFilter.tsx
@@ -155,12 +155,11 @@ export const ClubFilter: React.FC<FilterAreaProps> = (props) => {
               <PortalButton
                 pbstyle="solid"
                 width="7rem"
-                onClick={() =>
-                  {props.dispatchFilterValues({ type: RESET_FILTER })
+                onClick={() => {
+                  props.dispatchFilterValues({ type: RESET_FILTER })
                   props.setKeyword("")
                   setValue("keyword", "")
-                }
-                }
+                }}
               >
                 リセット
               </PortalButton>
@@ -255,8 +254,7 @@ export const ClubFilter: React.FC<FilterAreaProps> = (props) => {
                         width="7rem"
                         onClick={() => {
                           props.dispatchFilterValues({ type: RESET_FILTER })
-                        }
-                        }
+                        }}
                       >
                         リセット
                       </PortalButton>

--- a/src/components/global/Header/Header.tsx
+++ b/src/components/global/Header/Header.tsx
@@ -6,7 +6,9 @@ import { HEADER_HEIGHT } from "../../../utils/consts"
 import { HamburgerMenu } from "./HamburgerMenu"
 import { UserMenu } from "./UserMenu"
 
-export const Header: React.FC<{ session: Session }> = ({ session }) => {
+export const Header: React.FC<{ session: Session | undefined }> = ({
+  session,
+}) => {
   return (
     <HStack
       px="1rem"

--- a/src/components/global/Header/UserMenu.tsx
+++ b/src/components/global/Header/UserMenu.tsx
@@ -68,19 +68,19 @@ export const UserMenu: React.FC<{ session: Session | undefined }> = ({
       onClose={onClose}
       placement="bottom-end"
     >
-        {isLoading ? (
-          <Loading />
-        ) : (
-            <PopoverTrigger>
+      {isLoading ? (
+        <Loading />
+      ) : (
+        <PopoverTrigger>
           <Button p="0" backgroundColor="transparent">
             {session ? (
               <Avatar src={session.avatar} {...avatarProps} />
-              ) : (
+            ) : (
               <DefaultUserIcon {...avatarProps} />
-              )}
+            )}
           </Button>
-      </PopoverTrigger>
-        )}
+        </PopoverTrigger>
+      )}
       <PopoverContent w={adjustPopoverWidth ? "90vw" : "20em"}>
         <PopoverBody>
           {session ? (

--- a/src/components/global/Header/UserMenu.tsx
+++ b/src/components/global/Header/UserMenu.tsx
@@ -20,17 +20,20 @@ import type { Session } from "../../../types/api"
 import { axiosFetcher } from "../../../utils/axios"
 import { PortalButton } from "../../common/Button"
 import { DefaultUserIcon } from "../../common/Icon"
+import { Loading } from "../LoadingPage"
 
-export const UserMenu: React.FC<{ session: Session }> = ({ session }) => {
+export const UserMenu: React.FC<{ session: Session | undefined }> = ({
+  session,
+}) => {
   const { isOpen, onOpen, onClose } = useDisclosure()
   const loc = useLocation()
-  const { mutate } = useSession()
+  const { isLoading, mutate } = useSession()
   const [adjustPopoverWidth] = useMediaQuery("(max-width: 21em)")
-  const { setIsLoading } = useSetLoadingStateContext()
+  const { setIsLoadingOuter } = useSetLoadingStateContext()
   const errorToast = useErrorToast("正常にログアウトできませんでした")
 
   const onLogout = async () => {
-    setIsLoading(true)
+    setIsLoadingOuter(true)
     try {
       await mutate(
         async () => {
@@ -45,7 +48,7 @@ export const UserMenu: React.FC<{ session: Session }> = ({ session }) => {
       console.error(e)
       errorToast()
     } finally {
-      setIsLoading(false)
+      setIsLoadingOuter(false)
     }
   }
 
@@ -65,15 +68,19 @@ export const UserMenu: React.FC<{ session: Session }> = ({ session }) => {
       onClose={onClose}
       placement="bottom-end"
     >
-      <PopoverTrigger>
-        <Button p="0" backgroundColor="transparent">
-          {session ? (
-            <Avatar src={session.avatar} {...avatarProps} />
-          ) : (
-            <DefaultUserIcon {...avatarProps} />
-          )}
-        </Button>
+        {isLoading ? (
+          <Loading />
+        ) : (
+            <PopoverTrigger>
+          <Button p="0" backgroundColor="transparent">
+            {session ? (
+              <Avatar src={session.avatar} {...avatarProps} />
+              ) : (
+              <DefaultUserIcon {...avatarProps} />
+              )}
+          </Button>
       </PopoverTrigger>
+        )}
       <PopoverContent w={adjustPopoverWidth ? "90vw" : "20em"}>
         <PopoverBody>
           {session ? (

--- a/src/components/global/LoadingPage.tsx
+++ b/src/components/global/LoadingPage.tsx
@@ -28,7 +28,14 @@ export const LoadingOverlay: React.FC<{}> = () => {
   const { isLoadingOuter } = useLoadingStateContext()
 
   return isLoadingOuter ? (
-    <Box minH="100vh" minW="100vw" zIndex={Infinity} position="absolute" top="0" left="0">
+    <Box
+      minH="100vh"
+      minW="100vw"
+      zIndex={Infinity}
+      position="absolute"
+      top="0"
+      left="0"
+    >
       <Container maxW="2xl" height="100vh">
         <Flex direction="column" align="center" justify="center" height="100%">
           <Center>

--- a/src/components/global/LoadingPage.tsx
+++ b/src/components/global/LoadingPage.tsx
@@ -1,10 +1,12 @@
 import { Box, Center, Container, Flex, Spinner } from "@chakra-ui/react"
 import { motion } from "framer-motion"
 
-export const Loading: React.FC<{ fullScreen?: boolean }> = (props) => {
+import { useLoadingStateContext } from "../../contexts/loading"
+
+export const Loading: React.FC<{}> = () => {
   return (
     <motion.div exit={{ opacity: 0 }}>
-      <Box minH={props.fullScreen ? "100vh" : "100%"}>
+      <Box minH="100%">
         <Container maxW="2xl" height="100vh">
           <Flex
             direction="column"
@@ -19,5 +21,23 @@ export const Loading: React.FC<{ fullScreen?: boolean }> = (props) => {
         </Container>
       </Box>
     </motion.div>
+  )
+}
+
+export const LoadingOverlay: React.FC<{}> = () => {
+  const { isLoadingOuter } = useLoadingStateContext()
+
+  return isLoadingOuter ? (
+    <Box minH="100vh" minW="100vw" zIndex={Infinity} position="absolute" top="0" left="0">
+      <Container maxW="2xl" height="100vh">
+        <Flex direction="column" align="center" justify="center" height="100%">
+          <Center>
+            <Spinner size="xl" />
+          </Center>
+        </Flex>
+      </Container>
+    </Box>
+  ) : (
+    <></>
   )
 }

--- a/src/components/global/Route/UserRoute.tsx
+++ b/src/components/global/Route/UserRoute.tsx
@@ -6,7 +6,7 @@ import type { UserInfo } from "../../../types/api"
 
 export const UserRouteElement: React.FC<{}> = () => {
   const { data } = useAPI<UserInfo>("/api/v1/users")
-  const { isLoading } = useLoadingStateContext()
+  const { isLoadingOuter } = useLoadingStateContext()
 
-  return <>{!isLoading && data && <Outlet context={data} />}</>
+  return <>{!isLoadingOuter && data && <Outlet context={data} />}</>
 }

--- a/src/contexts/loading.ts
+++ b/src/contexts/loading.ts
@@ -4,22 +4,26 @@ import React, { useContext } from "react"
 import type { ErrorType, StateDispatch } from "../types/utils"
 
 type LoadingState = {
-  isLoading: boolean
+  isLoadingOuter: boolean
+  isLoadingInner: boolean
   error: ErrorType
 }
 
 type SetLoadingState = {
-  setIsLoading: StateDispatch<boolean>
+  setIsLoadingOuter: StateDispatch<boolean>
+  setIsLoadingInner: StateDispatch<boolean>
   setError: StateDispatch<ErrorType>
 }
 
 export const LoadingStateContext = React.createContext<LoadingState>({
-  isLoading: false,
+  isLoadingOuter: false,
+  isLoadingInner: false,
   error: undefined,
 })
 
 export const SetLoadingStateContext = React.createContext<SetLoadingState>({
-  setIsLoading: () => {},
+  setIsLoadingOuter: () => {},
+  setIsLoadingInner: () => {},
   setError: () => {},
 })
 

--- a/src/hooks/useAPI.ts
+++ b/src/hooks/useAPI.ts
@@ -7,14 +7,14 @@ import type { APIResponse } from "../types/api"
 
 type EndpointArg<T> = T extends null ? null : string
 
-export function useAPI<R extends APIResponse | null>(
+export function useAPI<R extends APIResponse | null, S = R>(
   endpoint: EndpointArg<R> | (() => EndpointArg<R>),
   isImmutable?: boolean,
-  isNotUpdateLoadingState?: boolean
+  isInner?: boolean
 ) {
-  const { setIsLoading } = useSetLoadingStateContext()
+  const { setIsLoadingOuter, setIsLoadingInner } = useSetLoadingStateContext()
   const { data, error, isLoading, mutate } = useSWR<
-    R | undefined,
+    S | undefined,
     AxiosError | Error
   >(
     endpoint,
@@ -27,12 +27,15 @@ export function useAPI<R extends APIResponse | null>(
       : {}
   )
 
-  // XXX: Add dependency and testing.
   useEffect(() => {
-    if (isLoading && !isNotUpdateLoadingState) {
-      setIsLoading(true)
+    if (isLoading) {
+      if (isInner) {
+        setIsLoadingInner(true)
+      } else {
+        setIsLoadingOuter(true)
+      }
     }
-  })
+  }, [isInner, isLoading, setIsLoadingInner, setIsLoadingOuter])
 
   return {
     data: data,

--- a/src/hooks/useClubDisplay.ts
+++ b/src/hooks/useClubDisplay.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react"
+import { useMemo, useState } from "react"
 
 import type { ClubPageExternal } from "../types/api"
 import type { FilterStateType } from "../types/reducer"
@@ -8,9 +8,12 @@ import { useAPI } from "./useAPI"
 export function useClubDisplay(
   arr: Array<ClubPageExternal> | undefined,
   state: FilterStateType,
-  keyword: string
 ) {
-  const { data } = useAPI<Array<ClubPageExternal> | null>(
+  const [keyword, setKeyword] = useState<string>("")
+  const { data } = useAPI<
+    Array<ClubPageExternal> | null,
+    Array<ClubPageExternal>
+  >(
     keyword === "" ? null : `/api/v1/clubs/search?content=${keyword}`,
     false,
     true
@@ -37,7 +40,7 @@ export function useClubDisplay(
       return true
     })
   }, [arr, state])
-  const sortedClub = useMemo<typeof arr>(() => {
+  const sortedClubs = useMemo<typeof arr>(() => {
     return filteredClub?.sort((val1, val2) => {
       if (state.isAscending) {
         return val1.name.localeCompare(val2.name)
@@ -47,5 +50,5 @@ export function useClubDisplay(
     })
   }, [filteredClub, state.isAscending])
 
-  return sortedClub
+  return { sortedClubs, keyword, setKeyword }
 }

--- a/src/hooks/useClubDisplay.ts
+++ b/src/hooks/useClubDisplay.ts
@@ -7,7 +7,7 @@ import { useAPI } from "./useAPI"
 
 export function useClubDisplay(
   arr: Array<ClubPageExternal> | undefined,
-  state: FilterStateType,
+  state: FilterStateType
 ) {
   const [keyword, setKeyword] = useState<string>("")
   const { data } = useAPI<

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -6,7 +6,7 @@ import { useSetLoadingStateContext } from "../contexts/loading"
 import type { Session } from "../types/api"
 
 export function useSession() {
-  const { setIsLoading } = useSetLoadingStateContext()
+  const { setIsLoadingInner } = useSetLoadingStateContext()
   const { data, error, isLoading, mutate } = useSWR<
     Session,
     Error | AxiosError
@@ -14,12 +14,12 @@ export function useSession() {
 
   useEffect(() => {
     if (isLoading) {
-      setIsLoading(true)
+      setIsLoadingInner(true)
     }
-  })
+  }, [isLoading, setIsLoadingInner])
 
   return {
-    session: data as Session,
+    session: data,
     isLoading: isLoading,
     error: error,
     mutate: mutate,

--- a/src/pages/clubs.tsx
+++ b/src/pages/clubs.tsx
@@ -7,7 +7,7 @@ import {
   useMediaQuery,
   VStack,
 } from "@chakra-ui/react"
-import { useReducer, useState } from "react"
+import { useReducer } from "react"
 import { Link } from "react-router-dom"
 
 import { ClubCard } from "../components/common/Clubs/ClubCard"
@@ -15,6 +15,7 @@ import { ClubFilter } from "../components/common/Clubs/ClubFilter"
 import { ClubSortOptionSelect } from "../components/common/Clubs/ClubSortOptionSelect"
 import { TitleArea } from "../components/global/Header/TitleArea"
 import { Loading } from "../components/global/LoadingPage"
+import { useLoadingStateContext } from "../contexts/loading"
 import { useAPI } from "../hooks/useAPI"
 import { useClubDisplay } from "../hooks/useClubDisplay"
 import { filterReducer } from "../reducer/filter"
@@ -23,8 +24,9 @@ import { PADDING_BEFORE_FOOTER } from "../utils/consts"
 import { getActivity, getCampus } from "../utils/functions"
 
 const AnimatedClubs: React.FC<{}> = () => {
-  const { data, isLoading } = useAPI<Array<ClubPageExternal>>(
+  const { data } = useAPI<Array<ClubPageExternal>>(
     "/api/v1/clubs",
+    true,
     true
   )
   const [state, dispatch] = useReducer(filterReducer, {
@@ -35,10 +37,10 @@ const AnimatedClubs: React.FC<{}> = () => {
     isCommittee: true,
     isAscending: true,
   })
-  const [keyword, setKeyword] = useState<string>("")
   const [isMobileLayout] = useMediaQuery("(max-width: 62em)")
   const [isSmallPadding] = useMediaQuery("(max-width: 30em)")
-  const sortedClubs = useClubDisplay(data, state, keyword)
+  const { sortedClubs, keyword, setKeyword } = useClubDisplay(data, state)
+  const { isLoadingInner } = useLoadingStateContext()
 
   return (
     <VStack
@@ -58,6 +60,7 @@ const AnimatedClubs: React.FC<{}> = () => {
         <ClubFilter
           filterValues={state}
           dispatchFilterValues={dispatch}
+          keyword={keyword}
           setKeyword={setKeyword}
           isMobileLayout={isMobileLayout}
         />
@@ -75,7 +78,7 @@ const AnimatedClubs: React.FC<{}> = () => {
               isAscending={state.isAscending}
               dispatchIsAscending={dispatch}
             />
-            {!isLoading && sortedClubs ? (
+            {!isLoadingInner && sortedClubs ? (
               <>
                 <Grid
                   templateColumns={{

--- a/src/pages/clubs.tsx
+++ b/src/pages/clubs.tsx
@@ -24,11 +24,7 @@ import { PADDING_BEFORE_FOOTER } from "../utils/consts"
 import { getActivity, getCampus } from "../utils/functions"
 
 const AnimatedClubs: React.FC<{}> = () => {
-  const { data } = useAPI<Array<ClubPageExternal>>(
-    "/api/v1/clubs",
-    true,
-    true
-  )
+  const { data } = useAPI<Array<ClubPageExternal>>("/api/v1/clubs", true, true)
   const [state, dispatch] = useReducer(filterReducer, {
     isHachiojiCampus: true,
     isKamataCampus: true,

--- a/src/pages/favorites.tsx
+++ b/src/pages/favorites.tsx
@@ -38,7 +38,7 @@ export const AnimatedFavorites: React.FC<{}> = () => {
     isCommittee: true,
     isAscending: true,
   })
-  const sortedClubs = useClubDisplay(data, state, "")
+  const { sortedClubs } = useClubDisplay(data, state)
 
   return (
     <VStack flex="1" spacing="2rem">

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -6,7 +6,6 @@ import { BrowserRouter, Route, Routes, useLocation } from "react-router-dom"
 
 import { Footer } from "./components/global/Footer"
 import { Header } from "./components/global/Header/Header"
-import { Loading } from "./components/global/LoadingPage"
 import { ClubRouteElement } from "./components/global/Route/ClubRoute"
 import { DomainUserRouteElement } from "./components/global/Route/DomainUserRoute"
 import { UserRouteElement } from "./components/global/Route/UserRoute"
@@ -21,7 +20,7 @@ import * as page from "./pages"
 const AnimatedRouter: React.FC<{}> = () => {
   const location = useLocation()
   const { session } = useSession()
-  const { isLoading, error } = useLoadingStateContext()
+  const { error } = useLoadingStateContext()
   const { setError } = useSetLoadingStateContext()
 
   useEffect(() => {
@@ -32,86 +31,71 @@ const AnimatedRouter: React.FC<{}> = () => {
   if (error) {
     if (isAxiosError(error)) {
       return (
-        <Flex direction="column" minH="100vh">
-          <Header session={session} />
-          <Flex p="0" flex="1">
-            <AnimatePresence mode="wait" initial={false}>
-              {error.response?.status === 401 ? (
-                <page.UnauthorizedPage />
-              ) : (
-                <page.ErrorPage />
-              )}
-            </AnimatePresence>
-          </Flex>
-          <Footer />
-        </Flex>
+        <AnimatePresence mode="wait" initial={false}>
+          {error.response?.status === 401 ? (
+            <page.UnauthorizedPage />
+          ) : (
+            <page.ErrorPage />
+          )}
+        </AnimatePresence>
       )
     }
   }
 
-  if (isLoading) {
-    return (
-      <AnimatePresence mode="wait" initial={false}>
-        <Loading fullScreen />
-      </AnimatePresence>
-    )
-  }
-
   return (
-    <Flex direction="column" minH="100vh">
-      <Header session={session} />
-      <Flex p="0" flex="1">
-        <AnimatePresence mode="wait" initial={false}>
-          <Routes location={location} key={location.pathname}>
-            <Route index element={<page.Top />} />
-            <Route path="clubs">
-              <Route index element={<page.Clubs />} />
-              <Route
-                path=":slug"
-                element={
-                  <page.ClubPage
-                    userUUID={
-                      session?.role === "domain" ? session.userUuid : undefined
-                    }
-                  />
+    <AnimatePresence mode="wait" initial={false}>
+      <Routes location={location} key={location.pathname}>
+        <Route index element={<page.Top />} />
+        <Route path="clubs">
+          <Route index element={<page.Clubs />} />
+          <Route
+            path=":slug"
+            element={
+              <page.ClubPage
+                userUUID={
+                  session?.role === "domain" ? session.userUuid : undefined
                 }
               />
+            }
+          />
+        </Route>
+        <Route path="users" element={<UserRouteElement />}>
+          <Route path="club" element={<ClubRouteElement />}>
+            <Route path="edit">
+              <Route index element={<page.EditorList />} />
+              <Route path="description" element={<page.DescriptionEditor />} />
+              <Route path="detail" element={<page.DetailEditor />} />
+              <Route path="image" element={<page.ImageEditor />} />
+              <Route path="link" element={<page.LinkEditor />} />
+              <Route path="schedule" element={<page.ScheduleEditor />} />
+              <Route path="video" element={<page.VideoEditor />} />
+              <Route path="icon" element={<page.IconEditor />} />
             </Route>
-            <Route path="users" element={<UserRouteElement />}>
-              <Route path="club" element={<ClubRouteElement />}>
-                <Route path="edit">
-                  <Route index element={<page.EditorList />} />
-                  <Route
-                    path="description"
-                    element={<page.DescriptionEditor />}
-                  />
-                  <Route path="detail" element={<page.DetailEditor />} />
-                  <Route path="image" element={<page.ImageEditor />} />
-                  <Route path="link" element={<page.LinkEditor />} />
-                  <Route path="schedule" element={<page.ScheduleEditor />} />
-                  <Route path="video" element={<page.VideoEditor />} />
-                  <Route path="icon" element={<page.IconEditor />} />
-                </Route>
-              </Route>
-              <Route path="favs" element={<DomainUserRouteElement />}>
-                <Route index element={<page.Favorites />} />
-              </Route>
-              <Route path="edit" />
-              <Route path=":uuid" />
-            </Route>
-            <Route path="*" element={<page.NotFound />} />
-          </Routes>
-        </AnimatePresence>
-      </Flex>
-      <Footer />
-    </Flex>
+          </Route>
+          <Route path="favs" element={<DomainUserRouteElement />}>
+            <Route index element={<page.Favorites />} />
+          </Route>
+          <Route path="edit" />
+          <Route path=":uuid" />
+        </Route>
+        <Route path="*" element={<page.NotFound />} />
+      </Routes>
+    </AnimatePresence>
   )
 }
 
 export const PortalRouter: React.FC<{}> = () => {
+  const { session } = useSession()
+
   return (
     <BrowserRouter>
-      <AnimatedRouter />
+      <Flex direction="column" minH="100vh">
+        <Header session={session} />
+        <Flex p="0" flex="1">
+          <AnimatedRouter />
+        </Flex>
+        <Footer />
+      </Flex>
     </BrowserRouter>
   )
 }


### PR DESCRIPTION
 # 概要
- ローディングの state を Outer, Inner で分けることで, `pages/club.tsx` でローディングの切り分けをしないように
  - デフォルトでは Outer 指定. Outer は LoadingOverlay コンポーネントとして Overlay の形で表示, Inner は従来の処理.
- 上記にともない hook `useAPI` をリファクタリング
- 検索を正常に動作するように
  - リセットボタンも検索で動作しなかったため動作させるように