### PR TITLE
アイコントリミング画面で初期トリミング枠を小さくした

### DIFF
--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -51,7 +51,7 @@ export function toPlaceID(buildingID: number, roomNumber: number) {
 
 export function makeCenterCrop(width: number, height: number) {
   return centerCrop(
-    makeAspectCrop({ unit: "%", width: 100 }, 1, width, height),
+    makeAspectCrop({ unit: "%", width: 50 }, 1, width, height),
     width,
     height
   )


### PR DESCRIPTION
# 概要

表題の通り、理由は後述

## 変更点

変更前:
<img width="489" alt="image" src="https://github.com/user-attachments/assets/bfa6b430-be16-4006-90af-7f19c3a05fef" />

変更後:
<img width="477" alt="image" src="https://github.com/user-attachments/assets/f20ad247-aa60-40cf-8271-e0bf736ca829" />

## 原因

使用しているライブラリ [react-image-crop](https://github.com/sekoyo/react-image-crop) のバグで初期選択時の `completedCrop` の値がずれているため、選択後の canvas 要素内の `drawImage` でそれが影響している

https://github.com/lc-tut/club-portal-frontend/blob/20be4c7304be775c4f17fffd4c48ea6fac62c0d4/src/pages/editor/icon.tsx#L67-L77

また、初期選択は `makeCenterCrop()` という中央にトリミング枠を置く処理をしている
https://github.com/lc-tut/club-portal-frontend/blob/20be4c7304be775c4f17fffd4c48ea6fac62c0d4/src/pages/editor/icon.tsx#L92

`makeCenterCrop()` では react-image-crop が提供している関数 (と使い方) をそのまま使っているため、前述の通りに react-image-crop のバグである可能性が非常に高い
https://github.com/lc-tut/club-portal-frontend/blob/20be4c7304be775c4f17fffd4c48ea6fac62c0d4/src/utils/functions.ts#L52-L58

なお、`completedCrop` はトリミング枠をクリックやドラッグなどで変更させれば正確な値になるのでユーザ側がそれの行為を行えるようにトリミング枠を小さくする対処にした